### PR TITLE
Updated streamlit_passwordless to v0.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "streamlit_passwordless" %}
-{% set version = "0.4.0" %}
+{% set version = "0.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 877ba5d78820ef0b448c357f65d706f8c2fd693a7124081c14c41b78d6a93af0
+  sha256: 3815ac4061e424e2ac92babb19dd7e7c39185689502b93ae8d7efaace9829975
 
 build:
   number: 0
@@ -22,7 +22,7 @@ requirements:
   run:
     - python >=3.11
     # Running the streamlit_passwordless custom component does not work with Streamlit v1.34 using conda.
-    - streamlit >=1.24,<=1.33
+    - streamlit >=1.24,!=1.34
     - passwordless >=0.1
     - pydantic >=2.0
 


### PR DESCRIPTION
Running the streamlit_passwordless custom component does not work with Streamlit v1.34 using conda, but it does work with v1.35. Changed the version requirement of Streamlit to exclude v1.34.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
