### PR TITLE
Updated streamlit_passwordless to version 0.11.0

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,3 +1,5 @@
+ace:
+- 8.0.2
 cdt_name:
 - conda
 channel_sources:
@@ -6,3 +8,11 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+python_min:
+- '3.9'

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Development: https://github.com/antonlydell/streamlit-passwordless
 
 Documentation: https://passwordless.streamlit.app
 
-streamlit-passwordless provides a user model for Streamlit applications based on the
-Bitwarden passwordless technology. It allows users to securely authenticate with a
-Streamlit application using the passkey FIDO2 and WebAuthn protocols.
+Streamlit Passwordless provides a user model for Streamlit applications, which allows
+users to securely authenticate with a Streamlit application using passkeys. It integrates
+with Bitwarden Passwordless.dev for the passkey management.
 
 
 Current build status

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "streamlit_passwordless" %}
-{% set version = "0.10.0" %}
+{% set version = "0.11.0" %}
 {% set pyproject = load_file_data('pyproject.toml') %}
 {% set requires_python = pyproject.get('project', {}).get('requires-python', '') %}
 {% set python_min = requires_python|replace('>=', '') %}
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8eee8376c33aaab97adf1b7d6966a43bdcfc596dffd6eaade83132881d0d729a
+  sha256: 293e720f2c813883b4fe0572c2a7001b12caf69289cd69f79712b1057886d137
 
 build:
   number: 0
@@ -24,6 +24,7 @@ requirements:
     - setuptools >=62.0
   run:
     - python >={{ python_min }}
+    - click >=8.0
     # Running the streamlit_passwordless custom component does not work with Streamlit v1.34 using conda.
     - streamlit >=1.24,!=1.34
     - passwordless >=0.1
@@ -43,9 +44,9 @@ about:
   home: https://github.com/antonlydell/streamlit-passwordless
   summary: 'A user model for Streamlit applications based on passwordless technology.'
   description: |
-    streamlit-passwordless provides a user model for Streamlit applications based on the
-    Bitwarden passwordless technology. It allows users to securely authenticate with a
-    Streamlit application using the passkey FIDO2 and WebAuthn protocols.
+    Streamlit Passwordless provides a user model for Streamlit applications, which allows
+    users to securely authenticate with a Streamlit application using passkeys. It integrates
+    with Bitwarden Passwordless.dev for the passkey management.
   license: MIT
   license_family: MIT
   license_file: LICENSE


### PR DESCRIPTION
`click` was added as a dependency for streamlit_passwordless in version 0.11.0. Updated the package description.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
